### PR TITLE
Fix legacy bridge poll timeout issues

### DIFF
--- a/custom_components/nexa_bridge_x/const.py
+++ b/custom_components/nexa_bridge_x/const.py
@@ -31,6 +31,9 @@ POLL_TIMEOUT = 60
 # How long to wait for a call to the bridge to respond
 CALL_TIMEOUT = 30
 
+# How long to wait for the initial poll request
+DISCOVERY_TIMEOUT = 120
+
 # How long for a websocket to reconnect after failure
 RECONNECT_SLEEP = 5
 

--- a/custom_components/nexa_bridge_x/nexa.py
+++ b/custom_components/nexa_bridge_x/nexa.py
@@ -344,7 +344,7 @@ class NexaApi:
 
         if (FORCE_NODE_ENUM or self.legacy) and not skip_enum:
             new_result = []
-            async for r in result:
+            for r in result:
                 try:
                     data = await self.fetch_node(r["id"])
                     new_result.append(data)

--- a/custom_components/nexa_bridge_x/nexa.py
+++ b/custom_components/nexa_bridge_x/nexa.py
@@ -24,6 +24,7 @@ from .const import (
     NODE_MEDIA_CAPABILITIES,
     POLL_INTERVAL,
     POLL_TIMEOUT,
+    DISCOVERY_TIMEOUT,
     CALL_TIMEOUT,
     RECONNECT_SLEEP,
     WS_PORT,
@@ -80,6 +81,10 @@ def values_from_events(node: NexaNodeData, legacy: bool) -> list[NexaNodeValue]:
                     data[prev_key],
                     data["time"]
                 ))
+    else:
+        if legacy and "capabilities" in node:
+            for key in node["capabilities"]:
+                values.append(NexaNodeValue(key, None, None, "0"))
 
     return values
 
@@ -333,14 +338,20 @@ class NexaApi:
         """Get information about bridge"""
         return await self.request("get", "info")
 
-    async def fetch_nodes(self) -> list[NexaNodeData]:
+    async def fetch_nodes(self, skip_enum: bool) -> list[NexaNodeData]:
         """Get all configured nodes"""
         result = await self.request("get", "nodes")
 
-        if FORCE_NODE_ENUM or self.legacy:
-            return await asyncio.gather(*[
-                self.fetch_node(r["id"]) for r in result
-            ])
+        if (FORCE_NODE_ENUM or self.legacy) and not skip_enum:
+            new_result = []
+            async for r in result:
+                try:
+                    data = await self.fetch_node(r["id"])
+                    new_result.append(data)
+                except:
+                    _LOGGER.error("Failed to enum node data: %s", r["id"])
+
+            return new_result
 
         return result
 
@@ -603,6 +614,7 @@ class NexaCoordinator(DataUpdateCoordinator):
         self.api = api
         self.legacy = legacy
         self.hass = hass
+        self.has_polled = False
 
     def get_node_by_id(self, node_id: str) -> NexaNode | None:
         """Gets node by id"""
@@ -654,10 +666,12 @@ class NexaCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> None:
         """Update data by pulling in the background"""
         try:
-            async with async_timeout.timeout(POLL_TIMEOUT):
+            timeout = POLL_TIMEOUT if self.has_polled else DISCOVERY_TIMEOUT
+
+            async with async_timeout.timeout(timeout):
                 results = await asyncio.gather(*[
                     self.api.fetch_info(),
-                    self.api.fetch_nodes(),
+                    self.api.fetch_nodes(self.has_polled),
                     self.api.fetch_energy(),
                     self.api.fetch_energy_nodes(),
                 ])
@@ -669,6 +683,8 @@ class NexaCoordinator(DataUpdateCoordinator):
                     list(map(lambda n: NexaNode(n, self.legacy), nodes)),
                     NexaEnergy(energy, energy_nodes, self.legacy)
                 )
+
+                self.has_polled = True
 
                 if self.data:
                     self.update_nodes_from_data(data)


### PR DESCRIPTION
Hopefully this fixes the timeout issues users have been reporting by creating another poll implementation for legacy bridges.

## Overview

> Changes only applies to legacy devices

* Only the first poll (aka "discovery") actually requests values from all nodes
* All the nodes are polled sequentially instead of concurrently
* All subsequent polls only fetches metadata
* The first poll has its own timeout value (and configuration)
* A failsafe was added if for some reason values are missing from data

## Potential downsides

* If a node value poll fails, the entity will not get any values in HA until an update from websocket comes in (or the integration is restarted and the poll succeeds this time)
  * This does get logged as an **error**
* If the websocket connection goes down and never reconnects for some reason, HA will get out of sync until restarted

---

* Fixes #34
* Fixes #32
* Refs #41
* Refs https://github.com/andersevenrud/ha-nexa-bridge-x/issues/15#issuecomment-1428622848